### PR TITLE
chore: require explicit SDD invocation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,14 +2,15 @@
 
 This repository uses Python Spec-Driven Development.
 
-Root `SPEC.md` is the source of truth. Relevant module `SPEC.md` files must be read before changes.
+Root `SPEC.md` and relevant module `SPEC.md` files are the grounding truth for implementation.
 
-For non-trivial work, do not jump directly to implementation:
+Ordinary discussion, explanation, review, and planning are read-only. Do not automatically load or invoke repository workflow skills.
 
-1. Use `.github/prompts/requirements-to-design.prompt.md` to clarify requirements and create a confirmed design document.
-2. Use `.github/prompts/spec-driven.prompt.md` with that design document path to update SPEC files, implement, verify, synchronize, and audit.
+Before creating, modifying, renaming, or deleting any repository file, require the user to explicitly invoke `/requirements-to-design <request>`. A natural-language edit request, a skill name mentioned in prose, or approval outside an explicit prompt invocation is not authorization to write; stop and direct the user to that command.
 
-Canonical workflow and architecture guidance lives in `skills/`. Prefer reading those files instead of duplicating rules here.
+After the design document is confirmed, only an explicit `/spec-driven <confirmed-design-document-path>` invocation may update relevant SPEC files. Non-SPEC repository files must not change until the user confirms those SPEC updates. There is no narrow-change exception.
+
+Read repository skills only when an explicitly invoked prompt directs you to them. This file is an entry point, not a project specification; keep project and module requirements in `SPEC.md` files.
 
 New Python source files must start with:
 
@@ -17,5 +18,3 @@ New Python source files must start with:
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 ```
-
-Do not treat this file as a project specification. Keep project and module requirements in `SPEC.md` files.

--- a/.github/prompts/requirements-to-design.prompt.md
+++ b/.github/prompts/requirements-to-design.prompt.md
@@ -1,7 +1,13 @@
+---
+name: requirements-to-design
+description: "Explicit SDD design phase for a requested repository modification"
+argument-hint: "Describe the repository modification"
+---
+
 # Requirements To Design
 
-Read `skills/requirements-to-design/SKILL.md` and follow it exactly.
+This is an explicit user-invoked SDD entry point. Read `.github/skills/requirements-to-design/SKILL.md` and follow it exactly.
 
-Use this prompt when requirements are unclear or non-trivial Python work needs a confirmed design document before SPEC changes.
+Use the requested repository modification passed to this prompt. If no request is provided, ask the user to invoke `/requirements-to-design <request>` and do not write any file.
 
-Do not write implementation code. Do not update `SPEC.md` files. End by giving the design document path and telling the user to run the spec-driven prompt with that path.
+Do not write implementation code or update `SPEC.md` files. The only permitted repository write is the user-confirmed design document. End by giving its path and telling the user to invoke `/spec-driven <confirmed-design-document-path>` explicitly.

--- a/.github/prompts/spec-driven.prompt.md
+++ b/.github/prompts/spec-driven.prompt.md
@@ -1,11 +1,19 @@
+---
+name: spec-driven
+description: "Explicit SPEC-first implementation from a confirmed design document"
+argument-hint: "Path to the confirmed design document"
+---
+
 # Spec Driven
+
+This is an explicit user-invoked SDD entry point. Require the prompt argument to be a confirmed design document path. If the path is missing, invalid, or not confirmed, stop without writing and ask the user to invoke `/spec-driven <confirmed-design-document-path>`; do not infer a path from ordinary conversation or editor state.
 
 Read these files before acting:
 
-- `skills/spec-driven/SKILL.md`
-- `skills/python-architecture/SKILL.md` when the work touches Python code
-- `skills/spec-implementation-audit/SKILL.md` before claiming completion
+- `.github/skills/spec-driven/SKILL.md`
+- `.github/skills/python-architecture/SKILL.md` when the work touches Python code
+- `.github/skills/spec-implementation-audit/SKILL.md` before claiming completion
 
-Use this prompt with an approved design document path. Update root/module `SPEC.md` files, ask the user to confirm SPEC changes, then implement, verify, synchronize, and audit.
+Update root/module `SPEC.md` files from the confirmed design and ask the user to confirm the SPEC changes. Do not modify any non-SPEC repository file before that confirmation. Once confirmed, implement against SPEC, verify, synchronize, and audit.
 
 Do not stop after SPEC updates unless the user has not confirmed them yet or a human decision is required.

--- a/.github/skills/python-architecture/SKILL.md
+++ b/.github/skills/python-architecture/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: python-architecture
-description: Use when designing, specifying, implementing, or auditing Python project architecture, package boundaries, public APIs, domain logic, persistence boundaries, or module dependencies.
+description: "Internal Python architecture rules loaded only when an explicitly invoked repository prompt directs the agent to this file."
+user-invocable: false
+disable-model-invocation: true
 ---
 
 # Python Architecture
 
-Use this as the Python architecture rules layer for SDD. It helps choose the simplest adequate architecture, write Python-aware `SPEC.md` sections, implement against those specs, and audit code/spec synchronization.
+This is the internal Python architecture rules layer for an explicitly invoked SDD workflow. It helps choose the simplest adequate architecture, write Python-aware `SPEC.md` sections, implement against those specs, and audit code/spec synchronization.
+
+## Invocation Gate
+
+Load this skill only when an explicitly invoked repository prompt directs the agent to this file. Ordinary discussion, explanation, review, planning, natural-language edit requests, skill-name mentions, and prose approvals must not trigger it.
 
 ## Core Principle
 

--- a/.github/skills/requirements-to-design/SKILL.md
+++ b/.github/skills/requirements-to-design/SKILL.md
@@ -1,15 +1,21 @@
 ---
 name: requirements-to-design
-description: Use when the user invokes requirements-to-design, asks to start an SDD design phase, or wants non-trivial Python work clarified into a confirmed design document before SPEC.md changes.
+description: "Internal rules loaded only by the explicit /requirements-to-design prompt. Produces a confirmed SDD design document without changing SPEC or implementation files."
+user-invocable: false
+disable-model-invocation: true
 ---
 
 # Requirements To Design
 
-Turn an idea into a reviewed design document. This skill is the front door of the SDD workflow. It clarifies intent and records design decisions, but it does not update `SPEC.md` files and does not implement code.
+Turn an explicitly supplied request into a reviewed design document. This internal skill implements the `/requirements-to-design` prompt; it clarifies intent and records design decisions, but it does not update `SPEC.md` files or implement code.
+
+## Invocation Gate
+
+Load this skill only when the user explicitly invokes `.github/prompts/requirements-to-design.prompt.md` with a requested repository modification. Ordinary discussion, explanation, review, planning, natural-language edit requests, skill-name mentions, and prose approvals must not trigger this skill. If the explicit prompt or its request is absent, stop without writing.
 
 ## Hard Gate
 
-Do not write implementation code. Do not update root or module `SPEC.md` files. The terminal state is a confirmed design document and a prompt for the user to invoke `spec-driven` with that design document path.
+Do not write implementation code. Do not update root or module `SPEC.md` files. The user-confirmed design document is the only permitted repository write. The terminal state is that confirmed document and a prompt for the user to invoke `/spec-driven` explicitly with its path.
 
 ## Process
 
@@ -21,7 +27,7 @@ Read enough local context before detailed questions:
 - Relevant module `SPEC.md` files, if the affected area is obvious.
 - `AGENTS.md`, `CLAUDE.md`, pyproject metadata, package layout, tests, and recent docs when useful.
 
-If no root `SPEC.md` exists, note that the target repository should create one before `spec-driven` implementation begins.
+If no root `SPEC.md` exists, note that the target repository must create one through the later `/spec-driven` SPEC phase before implementation begins.
 
 ### 2. Check Scope
 
@@ -94,7 +100,7 @@ After confirmation, end with exactly this shape:
 
 ```text
 Design document: docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md
-Next step: invoke spec-driven with this design document path.
+Next step: invoke /spec-driven with this design document path.
 ```
 
 ## Boundaries

--- a/.github/skills/spec-driven/SKILL.md
+++ b/.github/skills/spec-driven/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: spec-driven
-description: Use when the user invokes spec-driven with an approved design path, asks to update SPEC.md files from a confirmed design, or wants Python SDD implementation run from confirmed specs.
+description: "Internal rules loaded only by the explicit /spec-driven prompt with a confirmed design document path. Enforces SPEC confirmation before implementation."
+user-invocable: false
+disable-model-invocation: true
 ---
 
 # Spec-Driven Development
 
-Translate approved design intent into root/module `SPEC.md` files, get confirmation, then carry the work through implementation, verification, synchronization, and audit. This is the main execution skill after `requirements-to-design`.
+Translate an explicitly supplied confirmed design document into root/module `SPEC.md` files, get confirmation, then carry the work through implementation, verification, synchronization, and audit. This internal skill implements the `/spec-driven` prompt.
+
+## Invocation Gate
+
+Load this skill only when the user explicitly invokes `.github/prompts/spec-driven.prompt.md` with a confirmed design document path. Do not infer invocation or a design path from ordinary discussion, editor state, a natural-language edit request, a skill-name mention, or prose approval. If the explicit prompt, path, or confirmed design is absent, stop without writing and ask the user to invoke `/spec-driven <confirmed-design-document-path>`.
 
 ## Core Rule
 
@@ -14,7 +20,7 @@ Translate approved design intent into root/module `SPEC.md` files, get confirmat
 - Root `SPEC.md` owns current repository-wide architecture, module navigation, dependency diagrams, global development rules, and the SDD contract needed to run the project workflow.
 - Module `SPEC.md` files own current module contracts, public interfaces, internal structure, dependencies, error handling, architecture level, and current invariants.
 - Design documents, implementation notes, migration history, removed behavior, future roadmap, and detailed test matrices are not SPEC content unless they describe a currently supported compatibility behavior or a current verification obligation.
-- `CLAUDE.md` and `AGENTS.md` are thin agent entry points only. They point agents to root `SPEC.md`; they are not specifications.
+- `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` are thin agent entry points only. They point agents to root `SPEC.md`; they are not specifications.
 
 Implementation must not start until relevant `SPEC.md` changes are reviewed and confirmed.
 
@@ -33,7 +39,7 @@ Before writing or updating any `SPEC.md`, apply this filter:
 Do not stop after updating `SPEC.md`. Once the user confirms the SPEC changes, continue in the same turn whenever feasible:
 
 ```text
-approved design document
+explicit /spec-driven <confirmed-design-document-path>
   -> update root/module SPEC.md
   -> user confirms SPEC.md changes
   -> implement against confirmed SPEC.md
@@ -44,11 +50,11 @@ approved design document
   -> final report
 ```
 
-If the user invokes this with a task instead of a design path, identify whether an approved design already exists. If not and the change is non-trivial, stop and tell the user to invoke `requirements-to-design` first.
+If the user supplies a task, approval, or instruction instead of a confirmed design document path, stop without writing. Direct the user to `/requirements-to-design <request>` when no confirmed design exists, or `/spec-driven <confirmed-design-document-path>` when one does.
 
 ## Input Path
 
-When a confirmed design document exists, read it before editing specs:
+Read the confirmed design document supplied to the explicit prompt before editing specs:
 
 ```text
 docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md
@@ -118,9 +124,9 @@ If the sibling files are unavailable, apply the local Python rules below and con
 6. Implement only after confirmation.
 7. Run verification, synchronization, and audit.
 
-### Narrow bug fix
+### All repository modifications
 
-Bug fixes that do not change public interfaces or intended behavior may skip design-doc creation. Still read relevant specs, fix code, verify specs remain accurate, and update specs only if the bug reveals inaccurate or incomplete specification.
+Bug fixes, tests, configuration, documentation, agent customization, and other narrow changes do not bypass design confirmation or SPEC confirmation. Apply the existing-functionality procedure and keep the SPEC delta limited to legitimate current facts. If no legitimate current-fact SPEC delta exists, stop for a human decision rather than changing implementation or adding artificial SPEC content.
 
 ## Module SPEC Structure
 
@@ -172,7 +178,7 @@ After implementation, verify relevant specs still match code:
 - [ ] Module `SPEC.md` Dependencies match actual imports from other project modules.
 - [ ] Module `SPEC.md` Internal Structure lists actual module files.
 - [ ] Python Architecture section matches package layout, import direction, framework boundaries, and model boundaries.
-- [ ] Agent entry files remain thin pointers to root `SPEC.md`.
+- [ ] Agent entry files remain thin pointers to root `SPEC.md`, keep ordinary interaction read-only, and require explicit SDD prompt invocation before writes.
 - [ ] SPEC text contains current facts only; design process, historical narrative, target-state wording, future roadmap, and detailed test matrices are absent or moved elsewhere.
 
 If anything is out of sync, fix the spec or code before completion.

--- a/.github/skills/spec-implementation-audit/SKILL.md
+++ b/.github/skills/spec-implementation-audit/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: spec-implementation-audit
-description: Use after implementation and before completion claims, merge, or PR when work must be checked against confirmed SPEC.md files, Python architecture rules, and the actual diff.
+description: "Internal diff-based SPEC audit rules loaded only when an explicitly invoked repository prompt directs the agent to this file."
+user-invocable: false
+disable-model-invocation: true
 ---
 
 # SPEC Implementation Audit
 
-Determine whether implementation satisfies confirmed specifications. This is a SPEC-centered, diff-based audit. It is not a general test pass check and not a restatement of the implementer's summary.
+Determine whether implementation from an explicitly invoked SDD workflow satisfies confirmed specifications. This is a SPEC-centered, diff-based audit. It is not a general test pass check and not a restatement of the implementer's summary.
+
+## Invocation Gate
+
+Load this skill only when an explicitly invoked repository prompt directs the agent to this file. Ordinary discussion, explanation, review, planning, natural-language edit requests, skill-name mentions, and prose approvals must not trigger it.
 
 ## Core Rule
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,15 @@
 
 This repository uses Python Spec-Driven Development.
 
-Root `SPEC.md` is the project-level source of truth. Relevant module `SPEC.md` files must be read before changes.
+Root `SPEC.md` and relevant module `SPEC.md` files are the grounding truth for implementation.
 
-For non-trivial work:
+Ordinary discussion, explanation, review, and planning are read-only. Do not automatically load or invoke repository workflow skills.
 
-1. Invoke `requirements-to-design` to clarify requirements and produce a confirmed design document.
-2. After the user confirms the design, invoke `spec-driven` with the design document path.
-3. `spec-driven` updates SPEC files, waits for SPEC confirmation, implements, verifies, synchronizes, and audits.
+Before creating, modifying, renaming, or deleting any repository file, require the user to explicitly invoke `/requirements-to-design <request>`. A natural-language edit request, a skill name mentioned in prose, or approval outside an explicit prompt invocation is not authorization to write; stop and direct the user to that command.
 
-Use the repository skills under `.github/skills/` when available. For Python architecture decisions, apply `python-architecture` through the SDD flow.
+After the design document is confirmed, only an explicit `/spec-driven <confirmed-design-document-path>` invocation may update relevant SPEC files. Non-SPEC repository files must not change until the user confirms those SPEC updates. There is no narrow-change exception.
+
+Read repository skills only when an explicitly invoked prompt directs you to them. This file is an entry point, not a project specification; keep project and module requirements in `SPEC.md` files.
 
 New Python source files must start with:
 
@@ -18,5 +18,3 @@ New Python source files must start with:
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 ```
-
-Do not treat this file as a specification. Keep project and module requirements in `SPEC.md` files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,15 +2,15 @@
 
 This repository uses Python Spec-Driven Development.
 
-Root `SPEC.md` is the project-level source of truth. Relevant module `SPEC.md` files must be read before changes.
+Root `SPEC.md` and relevant module `SPEC.md` files are the grounding truth for implementation.
 
-For non-trivial work:
+Ordinary discussion, explanation, review, and planning are read-only. Do not automatically load or invoke repository workflow skills.
 
-1. Use `$requirements-to-design` to clarify requirements and produce a confirmed design document.
-2. After the user confirms the design, use `$spec-driven` with the design document path.
-3. `$spec-driven` updates SPEC files, waits for SPEC confirmation, implements, verifies, synchronizes, and audits.
+Before creating, modifying, renaming, or deleting any repository file, require the user to explicitly invoke `/requirements-to-design <request>`. A natural-language edit request, a skill name mentioned in prose, or approval outside an explicit prompt invocation is not authorization to write; stop and direct the user to that command.
 
-Use installed skills when available. For Python architecture decisions, apply `$python-architecture` through the SDD flow.
+After the design document is confirmed, only an explicit `/spec-driven <confirmed-design-document-path>` invocation may update relevant SPEC files. Non-SPEC repository files must not change until the user confirms those SPEC updates. There is no narrow-change exception.
+
+Read repository skills only when an explicitly invoked prompt directs you to them. This file is an entry point, not a project specification; keep project and module requirements in `SPEC.md` files.
 
 New Python source files must start with:
 
@@ -18,5 +18,3 @@ New Python source files must start with:
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 ```
-
-Do not treat this file as a specification. Keep project and module requirements in `SPEC.md` files.

--- a/SPEC.md
+++ b/SPEC.md
@@ -6,7 +6,9 @@ This repository uses spec-driven development. Root `SPEC.md` is the project-leve
 
 Root `SPEC.md` and module `SPEC.md` files are the current factual baseline for implementation. They describe present behavior, public contracts, module ownership, dependency direction, configuration surface, error semantics, architecture level, and implementation invariants.
 
-Spec-driven development uses design documents as inputs to produce confirmed SPEC deltas. Non-trivial development must update the relevant current-fact specs and receive confirmation before implementation. If implementation reveals that a spec is missing or wrong, implementation stops until the relevant spec is updated and confirmed. Bug fixes that do not change public interfaces or intended behavior may skip design-document creation, but must still read relevant specs and verify that they remain accurate.
+Every repository file modification uses the explicit two-phase SDD workflow. The user first explicitly invokes `.github/prompts/requirements-to-design.prompt.md` with the requested change; that phase may write only a user-confirmed design document and must not update SPEC or implementation files. The user then explicitly invokes `.github/prompts/spec-driven.prompt.md` with that confirmed design document path; that phase updates the relevant current-fact SPEC files and receives user confirmation before creating, modifying, renaming, or deleting any non-SPEC repository file. The confirmed design document is the only repository write permitted before SPEC confirmation.
+
+Ordinary discussion, explanation, review, and planning are read-only and must not automatically invoke repository workflow skills. A natural-language edit request, a skill name mentioned in prose, or approval given outside an explicit prompt invocation does not authorize a repository write or substitute for either explicit phase. There is no narrow-change exception. If implementation reveals that a spec is missing or wrong, implementation stops until the relevant spec is updated and confirmed.
 
 SPEC files must not carry design-process narrative, migration history, discarded alternatives, future roadmap, planned signatures, removed behavior that code no longer supports, or detailed test matrices. Current compatibility behavior and current rejection behavior may be specified, but must be written as present-tense facts.
 
@@ -183,10 +185,10 @@ flowchart TD
 - Provider construction lives in `providers`; `core` must use provider-neutral protocols and must not import provider/runtime modules.
 - Dynamic-only local helper utilities live as AgentTools in `tools`; recordable CommonTool and PlatformTool capabilities live in `core`, with CommonTool bodies in platform tool providers and backend PlatformTool bodies on concrete drivers. CommonTools and PlatformTools declare executable metadata through `capabilities`. All recordable capabilities must be registered before strict YAML parsing or SDK capability exposure, and platform registries must contain only inherited CommonTools plus the active platform's PlatformTools. AgentTools must not be registered for strict replay.
 - Replay, sensitivity, evidence, and tool-origin behavior must come from capability metadata and normalized `StepRunner` results, not hard-coded tool-name sets.
-- Public interface changes require `SPEC.md` update and user confirmation before implementation.
+- Every repository modification follows the explicit design-confirmation and SPEC-confirmation gates in the SDD contract; bug fixes, tests, configuration, documentation, and agent customization files have no bypass.
 - New platforms or capability groups require current-fact SPEC updates before implementation and must reuse shared capability declaration/registry contracts unless the confirmed SPEC changes the shared contract.
 - SPEC content must remain a current factual baseline. Design rationale, historical narrative, future roadmap, implementation plan, and detailed test matrices belong in design docs, reference docs, or tests rather than root or module SPEC files.
-- `CLAUDE.md` and `AGENTS.md` are agent entry points only. They must point to this root `SPEC.md` and must not duplicate project specification content.
+- `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` are thin, always-loaded agent entry points only. They enforce read-only ordinary interaction, require explicit SDD prompt invocation before writes, point to this root `SPEC.md`, and do not duplicate project specification or detailed workflow content.
 
 ## Python Architecture Rules
 


### PR DESCRIPTION
## Summary

Modify SDD workflow

## Related issue

na

## Design document

na

## SPEC updates

- root SPEC.md

## Changes

SDD only will be triggered by explicit invoke

## Verification

yes

## Evidence

na

## Checklist

### Spec-driven development

- [x] I reviewed root `SPEC.md` and every relevant module `SPEC.md`.
- [x] Any required design and SPEC confirmation gates occurred before implementation.
- [x] The implementation, tests, and documentation agree with the current confirmed SPEC files.
- [x] I used the current confirmed SPEC files, not the design document, as the implementation source of truth.

### Quality and safety

- [x] I ran focused tests and required formatting or lint checks, or explained why a check was not applicable.
- [x] I updated user-facing documentation when behavior or setup changed, or it is not applicable.
- [x] I did not commit credentials, tokens, account data, personal data, local `.env` files, generated logs, reports, screenshots, or workspace output.