### PR TITLE
ci: add cross-platform release install smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,10 +85,60 @@ jobs:
           path: dist/
           if-no-files-found: error
 
+  install-smoke:
+    name: Install smoke (${{ matrix.os }})
+    needs: verify
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Download verified distributions
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: python-distributions
+          path: dist/
+
+      - name: Install wheel and verify console scripts
+        shell: pwsh
+        run: |
+          $venv = Join-Path $env:RUNNER_TEMP "fsq-install-smoke"
+          python -m venv $venv
+          if ($IsWindows) {
+            $python = Join-Path $venv "Scripts/python.exe"
+            $fsq = Join-Path $venv "Scripts/fsq.exe"
+            $fsqAgent = Join-Path $venv "Scripts/fsq-agent.exe"
+          } else {
+            $python = Join-Path $venv "bin/python"
+            $fsq = Join-Path $venv "bin/fsq"
+            $fsqAgent = Join-Path $venv "bin/fsq-agent"
+          }
+          $wheels = @(Get-ChildItem -Path dist -Filter "*.whl")
+          if ($wheels.Count -ne 1) {
+            throw "Expected exactly one wheel in dist/, found $($wheels.Count)."
+          }
+          & $python -m pip install --upgrade pip
+          & $python -m pip install $wheels[0].FullName
+          & $python -c "import fsq_agent"
+          & $fsq --help
+          & $fsqAgent --help
+
   publish:
     name: Publish to PyPI
     if: ${{ inputs.publish }}
-    needs: verify
+    needs:
+      - verify
+      - install-smoke
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/docs/release-acceptance-checklist.md
+++ b/docs/release-acceptance-checklist.md
@@ -1,6 +1,6 @@
 # FSQ Release Acceptance Checklist
 
-Use this checklist for every release candidate. Run automated checks from a clean checkout, then complete the platform matrix on hosts that provide the real applications, browsers, devices, and services under test. A mocked unit test does not count as a platform acceptance result.
+Use this checklist for every release candidate. The release workflow automates source quality, package metadata, distribution checks, and clean installed-package smoke across GitHub-hosted Linux, macOS, and Windows runners. Complete the real-host platform matrix on hosts that provide the real applications, browsers, devices, and services under test. A mocked unit test does not count as a platform acceptance result.
 
 Record the commit SHA, operating system, Python version, installed artifact checksum, target identity, result, and evidence path for each run. Do not record credentials, tokens, API keys, `Authorization`, `Cookie`, or private target data.
 
@@ -8,8 +8,8 @@ Record the commit SHA, operating system, Python version, installed artifact chec
 
 A release candidate is ready only when:
 
-- quality, backend tests, frontend tests, frontend build, wheel build, and sdist build pass;
-- the wheel can be installed with `pip install fsq-agent` semantics in a clean Python 3.11+ environment without platform extras;
+- quality, backend tests, frontend tests, frontend build, package metadata guards, wheel build, and sdist build pass;
+- the verified wheel can be installed with `pip install fsq-agent` semantics in clean Python 3.11+ environments on Linux, macOS, and Windows without platform extras;
 - the installed distribution provides both `fsq` and `fsq-agent`, package-owned configuration/templates/skills, and both compiled frontends;
 - one real-host acceptance row passes for every supported platform included in the release;
 - Provider CLI and Control Plane read the same user-level configuration in both directions;
@@ -38,6 +38,8 @@ uv build
 
 Expected: all commands succeed, including the explicit clean-worktree assertion. Run this gate from a clean checkout of the candidate commit, not from an implementation worktree that still contains the proposed diff. Generated frontend output must exist before Python distributions are built. Local `.fsq/`, `runs/`, credentials, and test evidence must not enter the release commit or distribution.
 
+The release workflow runs the equivalent automated gate before publication, including package metadata guardrails, `twine check`, distribution contract tests, and upload of one verified `dist/` artifact consumed by downstream smoke and publish jobs.
+
 The CI package job is the executable contract for archive inspection. Confirm that it checks:
 
 - exactly one wheel and one sdist;
@@ -50,6 +52,8 @@ The CI package job is the executable contract for archive inspection. Confirm th
 
 ## 2. Clean Installation
 
+The release workflow automatically runs this smoke from the verified wheel artifact on `ubuntu-latest`, `macos-latest`, and `windows-latest`. Use this section for local reproduction, release-candidate spot checks, or investigating a failed matrix cell.
+
 Create a new temporary environment and install the built wheel without the repository on `PYTHONPATH`:
 
 ```bash
@@ -57,9 +61,18 @@ uv venv --python 3.11 /tmp/fsq-release-smoke
 uv pip install --python /tmp/fsq-release-smoke/bin/python dist/fsq_agent-*.whl
 /tmp/fsq-release-smoke/bin/fsq --help
 /tmp/fsq-release-smoke/bin/fsq-agent --help
+/tmp/fsq-release-smoke/bin/python -c "import fsq_agent"
 ```
 
-On Windows use the corresponding `Scripts\fsq.exe` and `Scripts\fsq-agent.exe` paths. Both help outputs must expose exactly the current top-level command families: `init`, `doctor`, `providers`, `case`, `runs`, and `ui`.
+On Windows use the corresponding paths:
+
+```powershell
+.\fsq-release-smoke\Scripts\fsq.exe --help
+.\fsq-release-smoke\Scripts\fsq-agent.exe --help
+.\fsq-release-smoke\Scripts\python.exe -c "import fsq_agent"
+```
+
+Both help outputs must expose exactly the current top-level command families: `init`, `doctor`, `providers`, `case`, `runs`, and `ui`.
 
 Run the remaining sections with the installed `fsq` executable.
 

--- a/tests/test_distribution_contract.py
+++ b/tests/test_distribution_contract.py
@@ -8,29 +8,34 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from packaging.version import Version
 
 ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_default_distribution_contract() -> None:
     project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    metadata = project["project"]
 
-    dependencies = project["project"]["dependencies"]
+    assert metadata["name"] == "fsq-agent"
+    version = Version(metadata["version"])
+    assert version.local is None
+    dependencies = metadata["dependencies"]
     for name in ("uiautomator2", "playwright", "pywinauto", "pillow", "Appium-Python-Client"):
         assert any(dependency.startswith(f"{name}==") for dependency in dependencies)
-    assert set(project["project"]["optional-dependencies"]) == {"dev"}
-    assert project["project"]["scripts"] == {
+    assert set(metadata["optional-dependencies"]) == {"dev"}
+    assert metadata["scripts"] == {
         "fsq": "fsq_agent.adapters.cli:main",
         "fsq-agent": "fsq_agent.adapters.cli:main",
     }
-    assert project["project"]["license"] == "MIT"
-    assert project["project"]["authors"] == [{"name": "Microsoft Corporation"}]
-    assert project["project"]["urls"] == {
+    assert metadata["license"] == "MIT"
+    assert metadata["authors"] == [{"name": "Microsoft Corporation"}]
+    assert metadata["urls"] == {
         "Documentation": "https://github.com/microsoft/FSQ#readme",
         "Issues": "https://github.com/microsoft/FSQ/issues",
         "Repository": "https://github.com/microsoft/FSQ",
     }
-    classifiers = set(project["project"]["classifiers"])
+    classifiers = set(metadata["classifiers"])
     assert "Operating System :: OS Independent" in classifiers
     assert "Intended Audience :: Developers" in classifiers
     for version in ("3.11", "3.12", "3.13"):
@@ -51,14 +56,26 @@ def test_release_workflow_is_manual_safe_and_uses_oidc_trusted_publishing() -> N
         "default": False,
     }
     assert workflow["permissions"] == {"contents": "read"}
-    assert set(workflow["jobs"]) == {"verify", "publish"}
+    assert set(workflow["jobs"]) == {"verify", "install-smoke", "publish"}
     publish = workflow["jobs"]["publish"]
     assert publish["if"] == "${{ inputs.publish }}"
-    assert publish["needs"] == "verify"
+    assert publish["needs"] == ["verify", "install-smoke"]
     assert publish["environment"] == "pypi"
     assert publish["permissions"] == {"contents": "read", "id-token": "write"}
     assert any(step.get("uses", "").startswith("actions/download-artifact@") for step in publish["steps"])
     assert publish["steps"][-1]["run"] == "uv publish --trusted-publishing always dist/*"
+    install_smoke = workflow["jobs"]["install-smoke"]
+    assert install_smoke["needs"] == "verify"
+    assert set(install_smoke["strategy"]["matrix"]["os"]) == {"ubuntu-latest", "macos-latest", "windows-latest"}
+    assert any(step.get("uses", "").startswith("actions/download-artifact@") for step in install_smoke["steps"])
+    install_smoke_commands = "\n".join(str(step.get("run", "")) for step in install_smoke["steps"])
+    for command in (
+        "python -m venv",
+        'python -c "import fsq_agent"',
+        "fsq",
+        "fsq-agent",
+    ):
+        assert command in install_smoke_commands
     verify = workflow["jobs"]["verify"]
     assert any(step.get("uses", "").startswith("actions/upload-artifact@") for step in verify["steps"])
     commands = "\n".join(str(step.get("run", "")) for step in verify["steps"])


### PR DESCRIPTION
**Description**
## Summary
- Add a release `install-smoke` matrix for Linux, macOS, and Windows.
- Verify the built wheel installs in a clean virtual environment and exposes both `fsq` and `fsq-agent`.
- Strengthen distribution contract tests for package metadata, version validity, release workflow shape, and publish gating.
- Update the release acceptance checklist to separate automated CI checks from manual real-host platform acceptance.

## Validation
- `.`python.exe` -m pytest tests/test_distribution_contract.py`  
- `.`python.exe` -m ruff check tests/test_distribution_contract.py`  
- `.`python.exe` -m ruff format --check tests/test_distribution_contract.py`  
- `git diff --check`  
- `.`python.exe` -m ruff check .`  
- `.`python.exe` -m ruff format --check .`  
- `.`python.exe` -m pytest`

## Notes
- The publish job still uses PyPI Trusted Publishing and does not introduce PyPI tokens.
- Publication remains manually triggered and gated by the `pypi` environment.
