### PR TITLE
fix: read macOS Appium server URL from FSQ_MACOS_APPIUM_SERVER_URL

### DIFF
--- a/fsq_agent/config/SPEC.md
+++ b/fsq_agent/config/SPEC.md
@@ -36,7 +36,7 @@ Current `__init__.py` exports via `__all__`:
 
 Repository-owned platform YAML presets contain stable, shareable runtime shape: active platform, backend selection, OpenAI Agents SDK turn limit, execution post-action delay defaults, lifecycle policy, harness policy, and reusable skill definitions. They do not define workspace, cases/output, project knowledge, target, or runtime-secret values. `config.example.yaml` is a reference sample only.
 
-Process environment and `.env` files do not contribute FSQ platform, application-target, runtime-secret, or Provider configuration and are not compatibility fallbacks. Config does not automatically parse repository or config-directory `.env` files.
+Process environment and `.env` files do not contribute FSQ platform, application-target, runtime-secret, or Provider configuration and are not compatibility fallbacks; the sole exception is the macOS operator-local Appium server URL, read from the `FSQ_MACOS_APPIUM_SERVER_URL` process environment variable when set. Config does not automatically parse repository or config-directory `.env` files.
 
 Optional top-level `caseLifecycle` is a strict execution policy block loaded as configuration only. Config validates hook shape with the same hook model used by FSQ case metadata; CLI strict execution owns hook path resolution, shell execution, recursion detection, lifecycle ordering, and failure semantics.
 
@@ -54,7 +54,7 @@ Shared configuration rules:
 - Both Control Plane child-directory creation and CLI explicit-root initialization produce the same canonical registered workspace identity and `.fsq/config/config.<platform>.yaml` layout. Explicit-root initialization may preserve unrelated pre-existing project content but never adopts pre-existing `.fsq` state or legacy markers.
 - Workspace `env` accepts only valid environment-variable names mapped to non-empty strings. Duplicate YAML keys, blank/invalid names, non-string values, and blank values fail without exposing values.
 - `caseLifecycle` remains preset-owned policy; config validates shape and strict entry layers own execution.
-- The user document owns Provider metadata and ordered workspace registry entries. Environment variables and `.env` files do not own FSQ settings.
+- The user document owns Provider metadata and ordered workspace registry entries. Environment variables and `.env` files do not own FSQ settings, except that a non-empty `FSQ_MACOS_APPIUM_SERVER_URL` overrides the macOS preset Appium server URL default in effective settings.
 
 Provider configuration:
 
@@ -94,7 +94,8 @@ macOS configuration:
 
 - `harness.macos.backend` supports `appium_mac2` in the first macOS backend.
 - `harness.macos.page_source_max_depth`, `harness.macos.action_timeout_seconds`, and `harness.macos.new_command_timeout_seconds` are YAML-owned stable defaults. The action timeout and Appium command-idle timeout are independent settings.
-- `harness.macos.appium_server_url` is a YAML field owned by the macOS preset and is required for macOS runtime validation. The committed macOS preset supplies `http://127.0.0.1:4723`.
+- `harness.macos.appium_server_url` is required for macOS runtime validation. The committed macOS preset supplies the default `http://127.0.0.1:4723`; the process environment variable `FSQ_MACOS_APPIUM_SERVER_URL`, when set to a non-empty value, overrides that default in the effective workspace-platform settings.
+- The operator-local Appium server URL is supplied by the `FSQ_MACOS_APPIUM_SERVER_URL` environment variable when set; otherwise the preset default applies. Config validates the resolved URL without connecting to the server.
 - Workspace target supplies optional `bundle_id` and `app_path`, with at least one required; a supplied app path must identify an existing application bundle or executable.
 - Missing Appium Python packages are reported during macOS runtime construction with actionable setup guidance, not during registry bootstrap. Missing or unusable Appium server URL, bundle id, app path, or path existence issues are reported by configuration validation before external actions begin.
 
@@ -124,7 +125,7 @@ Invalid or missing configuration raises `ConfigurationError` from `models`. YAML
 
 ## Current Invariants
 
-- Runtime configuration has three persisted ownership layers: repository presets own stable policy and platform endpoints/adapter modes, workspace config owns application target/paths/private runtime secrets, and the user document owns Provider metadata plus the workspace registry. Android device identity is transient run state owned by entry layers.
+- Runtime configuration has three persisted ownership layers: repository presets own stable policy and platform endpoint defaults/adapter modes, workspace config owns application target/paths/private runtime secrets, and the user document owns Provider metadata plus the workspace registry. Android device identity is transient run state owned by entry layers. The macOS Appium server URL is the one endpoint whose effective value may come from the operator process environment (`FSQ_MACOS_APPIUM_SERVER_URL`) instead of the preset default.
 - Public settings loads capture the latest complete user-provider snapshot. Long-lived entry surfaces may refresh only that snapshot at a documented complete-task boundary; an already constructed task/provider lifecycle is not mutated.
 - `caseLifecycle` remains an optional platform-YAML strict lifecycle policy. Config validates its shared FSQ hook shape; entry-layer strict execution owns path resolution, shell execution, recursion detection, ordering, and failure semantics.
 - There is no default provider. `openai_agents.provider` is `None` for explicit unconfigured state and otherwise stores the active user-provider type. Both providers use the configured non-empty model; no fixed GitHub model is injected.

--- a/fsq_agent/config/_loader.py
+++ b/fsq_agent/config/_loader.py
@@ -34,6 +34,8 @@ _PLATFORM_CONFIG_FILENAMES = {
     "macos": "config.macos.yaml",
 }
 
+_MACOS_APPIUM_SERVER_URL_ENV = "FSQ_MACOS_APPIUM_SERVER_URL"
+
 
 def _runtime_resource_root() -> Path:
     source_root = Path(__file__).resolve().parents[2]
@@ -167,6 +169,14 @@ def load_workspace_platform_settings(
     settings.runtime_secrets.set_values(workspace_config.env)
     settings = refresh_provider_settings(settings, user_config_root)
     resolve_workspace_runtime_paths(settings, workspace_root, preset_path.parent, platform_id)
+    return _apply_operator_environment(settings, platform_id)
+
+
+def _apply_operator_environment(settings: Settings, platform_id: str) -> Settings:
+    if platform_id == "macos":
+        operator_url = os.environ.get(_MACOS_APPIUM_SERVER_URL_ENV)
+        if operator_url and operator_url.strip():
+            settings.harness.macos.appium_server_url = operator_url.strip()
     return settings
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -137,6 +137,53 @@ env: {{}}
     assert settings.agent_context.knowledge.skills.dir == Path(__file__).parents[1] / "knowledge" / "skills"
 
 
+def _macos_workspace(tmp_path: Path, name: str) -> Path:
+    workspace = tmp_path / name
+    config_dir = workspace / ".fsq" / "config"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.macos.yaml").write_text(
+        f"""
+version: 2
+name: {name}
+root_path: {workspace.as_posix()}
+platform: macos
+target:
+    bundle_id: com.example.app
+env: {{}}
+""",
+        encoding="utf-8",
+    )
+    return workspace
+
+
+def test_load_workspace_platform_settings_macos_appium_url_reads_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    workspace = _macos_workspace(tmp_path, "macos-env-url")
+    monkeypatch.setenv("FSQ_MACOS_APPIUM_SERVER_URL", "http://appium.example:4777")
+
+    settings = load_workspace_platform_settings(workspace, "macos")
+
+    assert settings.harness.macos.appium_server_url == "http://appium.example:4777"
+
+
+def test_load_workspace_platform_settings_macos_appium_url_defaults_to_preset(
+    tmp_path: Path,
+) -> None:
+    workspace = _macos_workspace(tmp_path, "macos-preset-url")
+
+    settings = load_workspace_platform_settings(workspace, "macos")
+
+    assert settings.harness.macos.appium_server_url == "http://127.0.0.1:4723"
+
+
+def test_load_workspace_platform_settings_macos_ignores_blank_appium_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    workspace = _macos_workspace(tmp_path, "macos-blank-env")
+    monkeypatch.setenv("FSQ_MACOS_APPIUM_SERVER_URL", "   ")
+
+    settings = load_workspace_platform_settings(workspace, "macos")
+
+    assert settings.harness.macos.appium_server_url == "http://127.0.0.1:4723"
+
+
 def test_validate_runtime_settings_rejects_workspace_macos_path_that_is_not_bundle_or_executable(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Honor the operator-local Appium endpoint env var in workspace platform settings, overriding the preset default http://127.0.0.1:4723. Applies only to macos and only when the variable is set to a non-empty value; load_settings keeps ignoring process environment. Syncs the config module SPEC with the env-owned exception and adds coverage for set/unset/blank values.

## Summary

<!-- Describe the problem and the outcome of this pull request. -->

## Related issue

<!-- Use "Closes #123" for behavior or public-contract changes. If no issue is required for this change, explain why. -->

## Design document

<!-- Link the confirmed design document. If none is required, state whether this is a behavior-preserving bug fix or a documentation/repository-metadata change, and explain why the exception applies. -->

## SPEC updates

<!-- List every root or module SPEC updated and confirmed before implementation. If none changed, list the relevant SPEC files reviewed and explain why they remain accurate. -->

## Changes

<!-- Summarize the implementation, documentation, or repository-metadata changes. -->

## Verification

<!-- List the exact commands and manual checks run, including their outcomes. -->

## Evidence

<!-- Add screenshots, reports, or other user-visible evidence when relevant. Otherwise write "N/A" and explain why. -->

## Release or documentation impact

<!-- If this changes README, examples, packaging, release workflow, public media, or user-facing docs, describe the exact user-visible effect. Otherwise write "N/A". -->

## Checklist

### Spec-driven development

- [ ] I reviewed root `SPEC.md` and every relevant module `SPEC.md`.
- [ ] Any required design and SPEC confirmation gates occurred before implementation.
- [ ] The implementation, tests, and documentation agree with the current confirmed SPEC files.
- [ ] I used the current confirmed SPEC files, not the design document, as the implementation source of truth.

### Quality and safety

- [ ] I ran focused tests and required formatting or lint checks, or explained why a check was not applicable.
- [ ] I updated user-facing documentation when behavior or setup changed, or it is not applicable.
- [ ] I did not commit credentials, tokens, account data, personal data, local `.env` files, generated logs, reports, screenshots, or workspace output.
- [ ] I reviewed any included screenshots, videos, logs, reports, and Run artifacts for secrets, private paths, device identifiers, and account data.
- [ ] I did not add large binary media to Git history unless the repository already owns that exact artifact and the size is justified.
