### PR TITLE
docs: clarify README workflow sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,25 +32,27 @@ FSQ turns a natural-language UI goal into an observable automation run, saves sc
 
 ## Run existing Cases without an LLM
 
-Use FSQ like a test harness once a Case exists. Strict replay, Run history, and offline reports do **not** require a configured LLM Provider unless the authored Case contains an AI assertion.
+Use FSQ like a test harness once a Case exists. Run history and offline reports do **not** require a configured LLM Provider. Strict replay is also provider-free unless the authored Case contains an AI assertion.
 
 ```bash
 python -m pip install fsq-agent
 fsq init --platform web --browser-channel chrome
 # Store reviewed Case assets in your repo, for example: cases/web/*.fsq.yaml
-fsq case test --platform web cases/web/example-domain.fsq.yaml
+fsq case test --platform web cases/web/YOUR_CASE.fsq.yaml
 fsq runs show RUN_ID --open
 ```
 
-Configure an LLM Provider first, then use `fsq case create --platform web --goal "..."` when you want FSQ to operate the real UI and record a Run-local candidate `.fsq.yaml` Case. Coding agents should provide the goal and context; FSQ proves the path through live execution and evidence.
+## Create Cases with AI
+
+Configure an LLM Provider, then use `fsq case create --platform web --goal "..."` when you want FSQ to operate the real UI and create a reviewable `.fsq.yaml` Case from the successful Run. Coding agents should provide the goal and context; FSQ proves the path through live execution and evidence.
+
+## See FSQ in action
 
 <p align="center">
   <a href="https://youtu.be/QqCahxGDdS0">
     <img src="docs/media/fsq-v0.1.0-android-demo-preview.gif" alt="FSQ v0.1.0 animated demo preview: goal, execution, evidence, candidate Case, and report" width="880">
   </a>
 </p>
-
-https://github.com/user-attachments/assets/aa9d0a12-2f93-4894-8349-52a013424939
 
 <p align="center">
   <a href="https://youtu.be/QqCahxGDdS0">Watch the full demo on YouTube</a>
@@ -159,8 +161,8 @@ fsq runs list --platform web
 fsq runs show RUN_ID
 fsq runs logs RUN_ID
 
-# 3. Replay the reviewed Case deterministically before committing it.
-fsq case test --platform web cases/web/example-domain.fsq.yaml
+# 3. Replay the reviewed generated Case deterministically before committing it.
+fsq case test --platform web cases/web/RUN_ID.fsq.yaml
 ```
 
 The durable asset is the reviewed `.fsq.yaml` Case. The proof lives in `.fsq/runs/<platform>/<run-id>/` as events, screenshots, UI snapshots, evidence manifests, and reports. The strict replay path is provider-free, so CI and coding agents can verify committed Cases without configuring another LLM.

--- a/README.md
+++ b/README.md
@@ -54,9 +54,7 @@ Configure an LLM Provider, then use `fsq case create --platform web --goal "..."
   </a>
 </p>
 
-<p align="center">
-  <a href="https://youtu.be/QqCahxGDdS0">Watch the full demo on YouTube</a>
-</p>
+https://github.com/user-attachments/assets/aa9d0a12-2f93-4894-8349-52a013424939
 
 <p align="center">
   <img src="docs/assets/fsq-workflow.svg" alt="FSQ workflow: describe a goal, execute once, capture evidence, verify, review a Case, and replay deterministically" width="880">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -45,9 +45,7 @@ fsq runs show RUN_ID --open
   </a>
 </p>
 
-<p align="center">
-  <a href="https://youtu.be/QqCahxGDdS0">在 YouTube 观看完整演示</a>
-</p>
+https://github.com/user-attachments/assets/aa9d0a12-2f93-4894-8349-52a013424939
 
 <p align="center">
   <img src="docs/assets/fsq-workflow.svg" alt="FSQ 工作流：描述目标、执行一次、捕获证据、验证、审查 Case、确定性重放" width="880">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,13 +21,29 @@
 
 FSQ 会把一个自然语言 UI 目标变成可观察的自动化 Run，保存截图、UI Snapshot、事件和报告作为证据，并可把成功执行的真实动作转换为可审查的 Case，用于确定性重放。FSQ 使用 Playwright、uiautomator2、pywinauto 和 Appium 作为平台后端；它不会替代或自动安装这些后端所需的主机前置条件。
 
+## 无需 LLM，运行已有 Case
+
+已有 Case 后，可以把 FSQ 当作测试工具使用。查看 Run 历史和生成离线报告不需要配置 LLM Provider；严格重放也不需要 Provider，除非编写的 Case 包含 AI assertion。
+
+```bash
+python -m pip install fsq-agent
+fsq init --platform web --browser-channel chrome
+# 将审查后的 Case 保存在仓库中，例如：cases/web/*.fsq.yaml
+fsq case test --platform web cases/web/YOUR_CASE.fsq.yaml
+fsq runs show RUN_ID --open
+```
+
+## 使用 AI 创建 Case
+
+配置 LLM Provider 后，可以使用 `fsq case create --platform web --goal "..."`，让 FSQ 操作真实 UI，并根据成功的 Run 创建可审查的 `.fsq.yaml` Case。Coding agent 应提供目标和上下文；FSQ 通过真实执行和证据验证路径。
+
+## 查看 FSQ 实际运行
+
 <p align="center">
   <a href="https://youtu.be/QqCahxGDdS0">
     <img src="docs/media/fsq-v0.1.0-android-demo-preview.gif" alt="FSQ v0.1.0 动态演示预览：目标、执行、证据、候选 Case 和报告" width="880">
   </a>
 </p>
-
-https://github.com/user-attachments/assets/aa9d0a12-2f93-4894-8349-52a013424939
 
 <p align="center">
   <a href="https://youtu.be/QqCahxGDdS0">在 YouTube 观看完整演示</a>


### PR DESCRIPTION
## Summary

Clarify the README structure so provider-free replay, AI-assisted Case creation, and the product demo read as three distinct sections. Remove ambiguous Provider wording and make Case paths consistent with their role in each workflow.

## Related issue

No issue required. This is a documentation-only clarification of existing behavior.

## Design document

No design document required. This documentation change preserves existing behavior and public contracts.

## SPEC updates

No SPEC files changed. Reviewed SPEC.md and fsq_agent/cli/SPEC.md; they already define Provider boundaries, offline report behavior, deterministic replay, and successful Case publication. The README changes align the presentation with those existing contracts.

## Changes

- Split the introductory workflow into provider-free replay, AI Case creation, and product demo sections.
- Clarify that Run history and offline reports do not require a Provider, while strict replay only needs one for authored AI assertions.
- Use explicit placeholder/generated Case paths in examples.
- Remove the redundant bare video attachment URL.
- Add the corresponding positioning and structure to the Chinese README.

## Verification

- git diff --check — passed.
- Reviewed the complete two-file diff against SPEC.md and fsq_agent/cli/SPEC.md.
- Independent reviewer found no blocking content issue; its required structured follow-up could not be delivered because the agent message payload was cleared by the platform.

## Evidence

N/A. The change affects README hierarchy and wording only; no application UI or generated artifact changed.

## Release or documentation impact

The English and Chinese project landing pages now visually distinguish existing-Case replay, AI-assisted Case creation, and the demo. Provider requirements and example Case paths are less ambiguous for new users.

## Checklist

### Spec-driven development

- [x] I reviewed root SPEC.md and every relevant module SPEC.md.
- [x] Any required design and SPEC confirmation gates occurred before implementation.
- [x] The implementation, tests, and documentation agree with the current confirmed SPEC files.
- [x] I used the current confirmed SPEC files, not the design document, as the implementation source of truth.

### Quality and safety

- [x] I ran focused tests and required formatting or lint checks, or explained why a check was not applicable.
- [x] I updated user-facing documentation when behavior or setup changed, or it is not applicable.
- [x] I did not commit credentials, tokens, account data, personal data, local .env files, generated logs, reports, screenshots, or workspace output.
- [x] I reviewed any included screenshots, videos, logs, reports, and Run artifacts for secrets, private paths, device identifiers, and account data.
- [x] I did not add large binary media to Git history unless the repository already owns that exact artifact and the size is justified.