### PR TITLE
docs: simplify README demo media

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ Configure an LLM Provider, then use `fsq case create --platform web --goal "..."
 
 ## See FSQ in action
 
-<p align="center">
-  <a href="https://youtu.be/QqCahxGDdS0">
-    <img src="docs/media/fsq-v0.1.0-android-demo-preview.gif" alt="FSQ v0.1.0 animated demo preview: goal, execution, evidence, candidate Case, and report" width="880">
-  </a>
-</p>
+Watch FSQ turn a natural-language goal into live UI execution, captured evidence, a reviewable Case, and deterministic replay.
 
 https://github.com/user-attachments/assets/aa9d0a12-2f93-4894-8349-52a013424939
+
+<p align="center">
+  <a href="https://youtu.be/QqCahxGDdS0">Watch the full demo on YouTube</a>
+</p>
 
 <p align="center">
   <img src="docs/assets/fsq-workflow.svg" alt="FSQ workflow: describe a goal, execute once, capture evidence, verify, review a Case, and replay deterministically" width="880">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -39,13 +39,13 @@ fsq runs show RUN_ID --open
 
 ## 查看 FSQ 实际运行
 
-<p align="center">
-  <a href="https://youtu.be/QqCahxGDdS0">
-    <img src="docs/media/fsq-v0.1.0-android-demo-preview.gif" alt="FSQ v0.1.0 动态演示预览：目标、执行、证据、候选 Case 和报告" width="880">
-  </a>
-</p>
+观看 FSQ 如何把自然语言目标转化为真实 UI 执行、证据捕获、可审查 Case 和确定性重放。
 
 https://github.com/user-attachments/assets/aa9d0a12-2f93-4894-8349-52a013424939
+
+<p align="center">
+  <a href="https://youtu.be/QqCahxGDdS0">在 YouTube 观看完整演示</a>
+</p>
 
 <p align="center">
   <img src="docs/assets/fsq-workflow.svg" alt="FSQ 工作流：描述目标、执行一次、捕获证据、验证、审查 Case、确定性重放" width="880">

--- a/tests/test_distribution_contract.py
+++ b/tests/test_distribution_contract.py
@@ -217,7 +217,6 @@ def test_readme_uses_current_installation_and_cli_contract() -> None:
     assert "pip install fsq-agent" in readme
     assert "README.zh-CN.md" in readme
     assert "docs/getting-started.zh-CN.md" in readme
-    assert "docs/media/fsq-v0.1.0-android-demo-preview.gif" in readme
     assert "https://github.com/user-attachments/assets/aa9d0a12-2f93-4894-8349-52a013424939" in readme
     assert "https://youtu.be/QqCahxGDdS0" in readme
     hero = readme.split('<p align="center">\n  <img src="docs/assets/fsq-workflow.svg"', 1)[0]
@@ -247,7 +246,6 @@ def test_chinese_readme_uses_current_installation_and_cli_contract() -> None:
 
     assert "pip install fsq-agent" in readme
     assert "Workspace Root Strategy" in readme
-    assert "docs/media/fsq-v0.1.0-android-demo-preview.gif" in readme
     assert "https://github.com/user-attachments/assets/aa9d0a12-2f93-4894-8349-52a013424939" in readme
     assert "https://youtu.be/QqCahxGDdS0" in readme
     hero = readme.split('<p align="center">\n  <img src="docs/assets/fsq-workflow.svg"', 1)[0]


### PR DESCRIPTION
## Summary

Follow up on merged PR #74 by simplifying the README demo section. Remove the low-signal GIF preview and make the embedded video the primary demonstration.

## Related issue

No issue required. This is a documentation presentation change following review of the merged README structure.

## Design document

No design document required. This changes release-media presentation only and preserves product behavior and public contracts.

## SPEC updates

No SPEC files changed. Reviewed SPEC.md and fsq_agent/cli/SPEC.md; the change does not affect runtime behavior, CLI contracts, configuration, or module boundaries.

## Changes

- Remove the GIF preview from the English and Chinese README demo sections.
- Add a short sentence explaining that the video covers the goal, live UI execution, evidence, reviewable Case, and deterministic replay.
- Keep the GitHub attachment as the inline video and add an explicit YouTube link.
- Update the distribution contract so it continues to protect both video URLs without requiring the removed GIF.

## Verification

- git diff --check — passed.
- uv run --no-sync python -m pytest tests/test_distribution_contract.py -q — 12 passed.

## Evidence

N/A. This PR removes an existing preview and uses the already approved embedded video asset.

## Release or documentation impact

The README demo section now has one primary video instead of a dense GIF plus video. English and Chinese pages remain aligned.

## Checklist

### Spec-driven development

- [x] I reviewed root SPEC.md and every relevant module SPEC.md.
- [x] Any required design and SPEC confirmation gates occurred before implementation.
- [x] The implementation, tests, and documentation agree with the current confirmed SPEC files.
- [x] I used the current confirmed SPEC files, not the design document, as the implementation source of truth.

### Quality and safety

- [x] I ran focused tests and required formatting or lint checks, or explained why a check was not applicable.
- [x] I updated user-facing documentation when behavior or setup changed, or it is not applicable.
- [x] I did not commit credentials, tokens, account data, personal data, local .env files, generated logs, reports, screenshots, or workspace output.
- [x] I reviewed any included screenshots, videos, logs, reports, and Run artifacts for secrets, private paths, device identifiers, and account data.
- [x] I did not add large binary media to Git history unless the repository already owns that exact artifact and the size is justified.